### PR TITLE
Match parameterized routes

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -58,6 +58,8 @@ exports.handler = (route, options) => {
 };
 
 exports.response = (options, request) => {
+  let routes = require(options.router);
+  routes = routes.default || routes;
 
   // Here be dragons - we have to remove the fingerprint for paths that are set
   // up under a specific route like /bar/{route*}
@@ -65,33 +67,57 @@ exports.response = (options, request) => {
   const fingerPrintCheck = request.route.fingerprint.split('#');
   path = fingerPrintCheck.length > 1 ? request.path.replace(fingerPrintCheck[0], '/') : request.path;
 
-  const source = Object.assign({}, options, {
+  let props = options.props[path] && request.server.methods[options.props[path]] ?
+      request.server.methods[options.props[path]](request) : false;
+
+  if (props === false) {
+    match({ routes, location: path }, (error, redirectLocation, renderProps) => {
+      if (!!renderProps &&
+          renderProps.routes instanceof Array &&
+          !!renderProps.routes.length) {
+        let matchedRoute = null;
+        for (let i = 0; i < renderProps.routes.length; i++) {
+          const r = renderProps.routes[i];
+          if (r instanceof RoutingContext) {
+            continue;
+          }
+          if (r.hasOwnProperty('path')) {
+            matchedRoute = r;
+            break;
+          }
+        }
+        const routePath = matchedRoute.path;
+        const routePropsFn = request.server.methods[options.props[routePath]];
+        if (routePropsFn instanceof Function) props = routePropsFn(request, renderProps);
+      }
+    });
+  }
+
+  let source = Object.assign({}, options, {
     path: path,
     options: options,
-    props: options.props[path] && request.server.methods[options.props[path]] ?
-      request.server.methods[options.props[path]](request) : false
+    props: props
   });
 
-  return request.generateResponse(source, { variety: 'react', marshal: internals.marshal });
+  return request.generateResponse(source, { variety: 'react', marshal: internals.marshal(routes) });
 };
 
-internals.marshal = (response, next) => {
+internals.marshal = (routes) => {
+  Hoek.assert(routes instanceof Object, 'Routes object must be set');
+  return (response, next) => {
+    match({ routes, location: response.source.path }, (error, redirectLocation, renderProps) => {
 
-  let routes = require(response.source.router);
-  routes = routes.default || routes;
-
-  match({ routes, location: response.source.path }, (error, redirectLocation, renderProps) => {
-
-    if (error) {
-      next(Boom.wrap(error));
-    } else if (redirectLocation) {
-      next.redirect(redirectLocation.pathname + redirectLocation.search)
-    } else if (renderProps) {
-      internals.prepare(response, renderProps, next);
-    } else {
-      next(Boom.notFound('Not Found'));
-    }
-  })
+      if (error) {
+        next(Boom.wrap(error));
+      } else if (redirectLocation) {
+        next.redirect(redirectLocation.pathname + redirectLocation.search)
+      } else if (renderProps) {
+        internals.prepare(response, renderProps, next);
+      } else {
+        next(Boom.notFound('Not Found'));
+      }
+    });
+  };
 };
 
 

--- a/test/assets/app.jsx
+++ b/test/assets/app.jsx
@@ -5,7 +5,7 @@ const React = require('react');
 const App = React.createClass({
   render() {
     return (
-      <div className="foo">Hapi React Handler</div>
+      <div className="foo">Hapi React Handler {this.props.id}</div>
     )
   }
 });

--- a/test/assets/router.jsx
+++ b/test/assets/router.jsx
@@ -8,4 +8,5 @@ const App = require('./app.jsx');
 
 module.exports = <Router>
   <Route path="/foo" component={App} />
+  <Route path="/foo/:id" component={App} />
 </Router>;

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -31,7 +31,7 @@ lab.experiment('Hapi React Handler', () => {
         handler: {
           react: {
             relativeTo: Path.join(__dirname, 'assets'),
-            routerFile: 'router.jsx'
+            router: 'router.jsx'
           }
         }
       });
@@ -97,16 +97,24 @@ lab.experiment('Hapi React Handler with layout', () => {
         return done(error);
       }
 
+      server.method({
+        name: 'getTitle',
+        method: (req, props) => {
+          return {title: 'Foobar'};
+        }
+      })
+
+
       server.route({
         method: 'GET',
         path: '/{route*}',
         handler: {
           react: {
             relativeTo: Path.join(__dirname, 'assets'),
-            routerFile: 'router.jsx',
+            router: 'router.jsx',
             layout: 'layout.jsx',
             props: {
-              title: 'Foobar'
+              '/foo': 'getTitle'
             }
           }
         }
@@ -160,7 +168,7 @@ lab.experiment('Hapi React Handler specific path', () => {
         handler: {
           react: {
             relativeTo: Path.join(__dirname, 'assets'),
-            routerFile: 'router.jsx'
+            router: 'router.jsx'
           }
         }
       });
@@ -212,7 +220,7 @@ lab.experiment('Hapi React Handler sub-path', () => {
         handler: {
           react: {
             relativeTo: Path.join(__dirname, 'assets'),
-            routerFile: 'router.jsx'
+            router: 'router.jsx'
           }
         }
       });
@@ -264,7 +272,7 @@ lab.experiment('Hapi React Handler multiple sub-path', () => {
         handler: {
           react: {
             relativeTo: Path.join(__dirname, 'assets'),
-            routerFile: 'router.jsx'
+            router: 'router.jsx'
           }
         }
       });


### PR DESCRIPTION
Currently Quorra only matches static routes for passing props to the renderer. These changes allow routes like `/foo/:bar` to be matched:

```
...
handler: {
  react: {
    relativeTo: `${__dirname}/app`,
    router: 'routes.js',
    layout: 'layout.jsx' || 'myLayoutMethod',
    props: {
      '/': 'myIndexMethod',
      '/about': 'myAboutMethod',
      '/foo/:bar': 'myFooMethod'
    }
  }
}
...
```
